### PR TITLE
ダークモードでの「詳細」と「結果履歴」ページの修正

### DIFF
--- a/styleup/content.js
+++ b/styleup/content.js
@@ -836,7 +836,15 @@ function insertNewHeader() {
   mainNav.className = 'main-nav';
   
   // ロゴとメニューを追加
-  mainNav.appendChild(createLogo());
+  const logo = createLogo();
+
+  // mbl.php/question_results (結果履歴)ならロゴを非表示に
+  if (window.location.pathname.includes('/mbl.php/question_results')) {
+    logo.style.visibility = 'hidden';
+  }
+
+  mainNav.appendChild(logo);
+
   mainNav.appendChild(createMainMenu());
   
   // コンテナに要素を追加

--- a/styleup/styles.css
+++ b/styleup/styles.css
@@ -1724,17 +1724,17 @@ body.theme-dark .material-design-icon-icon svg {
 }
 
 /* すべてのページでリンク色をテーマカラーに統一 */
-a:not(.logo):not(.header-icon):not(.main-menu a):not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a) {
+a:not(.logo):not(.header-icon):not(.main-menu a):not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a):not(.btn):not(.active a) {
   color: var(--primary-color) !important;
   text-decoration: none;
 }
 
-a:not(.logo):not(.header-icon):not(.main-menu a):hover:not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a) {
+a:not(.logo):not(.header-icon):not(.main-menu a):hover:not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a):not(.btn):not(.active a) {
   text-decoration: underline;
 }
 
 /* ダークモードのリンク色 */
-body.theme-dark a:not(.logo):not(.header-icon):not(.main-menu a):not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a) {
+body.theme-dark a:not(.logo):not(.header-icon):not(.main-menu a):not(.dropdown-toggle):not(.theme-menu a):not(.dropdown-menu a):not(.btn):not(.active a) {
   color: var(--primary-color) !important;
 }
 
@@ -2104,4 +2104,47 @@ body.theme-dark .content button {
 body.theme-dark .msg button:hover,
 body.theme-dark .content button:hover {
   background-color: #4b5053 !important;
+}
+
+/* タブ */
+body.theme-dark .nav-tabs {
+  border-bottom-color: var(--border-color) !important;
+}
+
+body.theme-dark .nav-tabs a:hover {
+  background-color: var(--hover-color) !important;
+  border-color: transparent !important;
+  border-bottom-color: var(--border-color) !important;
+}
+
+body.theme-dark .nav-tabs .active a {
+  background-color: var(--background-color) !important;
+  color: var(--primary-color) !important;
+  border-color: var(--border-color) !important;
+  border-bottom-color: transparent !important;
+}
+
+/* 詳細ページ */
+body.theme-dark .contentsInfo-sectionTitle {
+  background: var(--active-color) !important;
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+}
+body.theme-dark .contentsInfoListData, .contentsInfoListLabel {
+  background: var(--background-color) !important;
+  color: var(--text-color) !important;
+}
+body.theme-dark .execUrlWrapper {
+  background-color: var(--hover-color) !important;
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+  scrollbar-color: var(--secondary-color) var(--hover-color) !important;
+}
+
+body.theme-dark .contentsInfoList {
+  border-color: var(--border-color) !important;
+}
+
+body.theme-dark .contentsInfoListLabel {
+  border-right-color: var(--border-color) !important;
 }

--- a/styleup/styles.css
+++ b/styleup/styles.css
@@ -2148,3 +2148,62 @@ body.theme-dark .contentsInfoList {
 body.theme-dark .contentsInfoListLabel {
   border-right-color: var(--border-color) !important;
 }
+
+/* 結果履歴のページ */
+.ui-content {
+  background-color: var(--background-color) !important;
+  color: var(--text-color) !important;
+}
+
+.ui-header {
+  background-color: var(--background-color) !important;
+  color: var(--text-color) !important;
+}
+
+.ui-title {
+  display: none !important;
+}
+
+.ui-bar-a {
+  background-color: var(--background-color) !important;
+  background-image: none !important;
+  color: var(--text-color) !important;
+  border: none !important;
+  border-radius: 0 !important;
+  margin-top: 5px !important;
+  margin-left: 12px !important;
+}
+
+a.ui-btn {
+  background-color: var(--background-color) !important;
+  background-image: none !important;
+  color: var(--text-color) !important;
+  border: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+}
+
+.ui-btn-inner {
+  background-color: var(--background-color) !important;
+  background-image: none !important;
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+  border: none !important;
+  border-radius: 0 !important;
+  font-size: 18px !important;
+  font-weight: lighter !important;
+}
+
+.ui-body-c {
+  margin-top: 64px !important;
+  background-color: var(--background-color) !important;
+  color: var(--text-color) !important;
+  text-shadow: none !important;
+}
+
+.ui-page, .ui-btn-up-c, .quotedUserText, .ui-overlay-c {
+  background-color: var(--background-color) !important;
+  background-image: none !important;
+  color: var(--text-color) !important;
+  text-shadow: none !important;
+}


### PR DESCRIPTION
こんにちは、非常に便利な拡張機能ですね！助かります。

![image](https://github.com/user-attachments/assets/a0d65b31-5ef6-4aef-aba6-3f6ca72c7c1a)

ダークモード設定時、**詳細**や `mbl.php/question_results` での**結果履歴**の表示にて文字色が白色になっていましたが、背景色も白色であったため、視認性を向上させるために背景色もダークモード時の背景色に対応させ、修正しました。
また、mbl.phpでの結果履歴のヘッダーを削除し、ロゴを「結果履歴」、「結果に戻る」に変更しました。